### PR TITLE
Adding Newsletter category and first newsletter in it

### DIFF
--- a/src/data/categories.json
+++ b/src/data/categories.json
@@ -111,5 +111,9 @@
   {
     "title": "Go",
     "icon": "devicon-go-plain colored"
+  },
+  {
+    "title": "Newsletter",
+    "icon": "devicon-javascript-plain colored"
   }
 ]

--- a/src/data/courses.json
+++ b/src/data/courses.json
@@ -754,7 +754,7 @@
     "title": "JavaScript Weekly",
     "description": "A free, once–weekly e-mail round-up of JavaScript news and articles.",
     "link": "http://javascriptweekly.com/",
-    "author": "Laracasts",
+    "author": "Cooper Press and Peter Cooper",
     "level": "Beginner,intermediate,advanced",
     "categories": "newsletter",
     "language": "English",

--- a/src/data/courses.json
+++ b/src/data/courses.json
@@ -749,6 +749,16 @@
     "categories": "vue",
     "language": "English",
     "flags": "flag-icon-us"
+  },
+  {
+    "title": "JavaScript Weekly",
+    "description": "A free, once–weekly e-mail round-up of JavaScript news and articles.",
+    "link": "http://javascriptweekly.com/",
+    "author": "Laracasts",
+    "level": "Beginner,intermediate,advanced",
+    "categories": "newsletter",
+    "language": "English",
+    "flags": "flag-icon-us"
   }
 ]
 


### PR DESCRIPTION
Adding Newsletter category and adding Javascript Weekly newsletter link. Please check and accept the PR.

I am setting the icon for this category as Javascript for now, as there is no icon for email/newsletter in devicons, we will update later.